### PR TITLE
Forces update of user Last Login timestamp

### DIFF
--- a/lib/Controller/LoginController.php
+++ b/lib/Controller/LoginController.php
@@ -153,6 +153,10 @@ class LoginController extends Controller
             'password' => $userPassword,
             'token' => empty($userPassword) ? $token : null,
         ], false);
+        
+        // Update the user's last login timestamp, since the conditions above tend to cause the
+        // completeLogin() call above to skip doing so.
+        $user->updateLastLoginTimestamp();
 
         //Workaround to create user files folder. Remove it later.
         \OC::$server->query(\OCP\Files\IRootFolder::class)->getUserFolder($user->getUID());


### PR DESCRIPTION
It seems like the conditions surrounding empty($userPassword) on line 154 causes UserSession::completeLogin() to skip updating the user's last login time.  We will do so manually afterwards, since all of these logins should be coming from organic people and not API calls.

This should fix Issue #132.